### PR TITLE
fix(makefile): modify makefile to recompile when editing headers

### DIFF
--- a/Src/led.c
+++ b/Src/led.c
@@ -1,6 +1,5 @@
 #include "stm32f4xx.h"
 #include "led.h"
-
 /* User Manual UM1472 states:
 
 User Green LED:    I/O PD12
@@ -71,6 +70,7 @@ void led_red_toggle(void)
     }
 }
 
+/* Toggle the blue LED */
 void led_blue_off(void)
 {
     if (GPIOD->ODR & GPIO_ODR_OD15) {

--- a/Src/main.c
+++ b/Src/main.c
@@ -8,7 +8,7 @@ int main(void)
 
 	while (1) {
 		for (i = 0; i < 1000000; i++) {}
-		led_red_toggle();
+		led_green_toggle();
 	}
 
 }


### PR DESCRIPTION
Add -MMD and -MP dependency flags to ensure the makefile "all" target will recompile if any changes to headers are made as well. Previously, even when modifying header files, the "make" command would not recompile the code.

The -include $(DEP_FLAGS) line MUST come after defining the build targets. Otherwise, the makefile will confuse the final target build as some .o file in the dependencies. Defining the -include $(DEP_FLAGS) after the build targets ensures the final sumobot_mini.elf is being correctly targeted for make all and uses the dependencies in the .d files to recompile if any changes to .c or .h files are made.