### PR TITLE
feat(cppcheck): add static analysis checking with cppcheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ Debug/
 .settings
 .metadata
 
+# ignore cppcheck report file
+cppcheck.report
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # Mini Sumobot
+
+## Toolchain
+STM32CubeIDE
+STM32Programmer
+Makefile
+

--- a/Src/led.c
+++ b/Src/led.c
@@ -1,4 +1,4 @@
-#include "stm32f4xx.h"
+#include <stm32f4xx.h>
 #include "led.h"
 /* User Manual UM1472 states:
 

--- a/Src/main.c
+++ b/Src/main.c
@@ -1,4 +1,4 @@
-#include "stm32f4xx.h"
+#include <stm32f4xx.h>
 #include "led.h"
 
 int main(void)
@@ -6,9 +6,11 @@ int main(void)
 	volatile unsigned int i;
 	led_initialize();
 
+
 	while (1) {
 		for (i = 0; i < 1000000; i++) {}
 		led_blue_toggle();
 	}
 
+	
 }

--- a/sumobot_mini.launch
+++ b/sumobot_mini.launch
@@ -70,7 +70,7 @@
     <stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="Debug/sumobot_mini.elf"/>
     <stringAttribute key="org.eclipse.cdt.launch.PROJECT_ATTR" value="sumobot_mini"/>
     <booleanAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_AUTO_ATTR" value="true"/>
-    <stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value=""/>
+    <stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.705962299"/>
     <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
         <listEntry value="/sumobot_mini"/>


### PR DESCRIPTION
Add appropriate flags for cppcheck to not spit out unnecessary errors and warnings related to unused functions and system header files. Most importantly, change the CMSIS vendor header files to be indicated as a system file <stm32f4xx.h> instead of "stm32f4xx.h" so cppcheck doesn't complain about missing header files.

The --suppress=missingIncludeSystem flag and setting the vendor headers to be system files is necessary for cppcheck to ignore static analyzing the CMSIS headers. Cppcheck is very slow when analyzing big if-def branches and the vendor file has plenty of that.

Run "make cppcheck" to run static analysis on all user added .c and .h files, ignoring the sysmem.c and syscalls.c. This is because these files hold stub functions to stop the compiler from complaining about missing system functions such as __write() and others from new/nanolib and thus, should not static analyzed.