### PR TITLE
feat(systick_delay): implement accurate hardware timer delay

### DIFF
--- a/Inc/systick.h
+++ b/Inc/systick.h
@@ -1,0 +1,8 @@
+#ifndef SYSTICK_H_
+#define SYSTICK_H_
+#include <stm32f4xx.h>
+
+void systick_initialize(void);
+void systick_delay_ms(uint32_t delay);
+
+#endif /* SYSTICK_H_ */

--- a/Src/main.c
+++ b/Src/main.c
@@ -1,24 +1,26 @@
 #include <stm32f4xx.h>
 #include "led.h"
 #include "gpio.h"
+#include "systick.h"
 
 int main(void)
 {
-	volatile unsigned int i;
+	//volatile unsigned int i;
 	led_initialize();
+	systick_initialize();
 	gpio_mode_set(LED_GREEN, GPIO_MODE_OUTPUT);
 	gpio_mode_set(LED_ORANGE, GPIO_MODE_OUTPUT);
 	gpio_mode_set(LED_RED, GPIO_MODE_OUTPUT);
 	gpio_mode_set(LED_BLUE, GPIO_MODE_OUTPUT);
 
 	while (1) {
-		for (i = 0; i < 1000000; i++) {}
+		systick_delay_ms(500);
 		led_green_toggle();
-		for (i = 0; i < 1000000; i++) {}
+		systick_delay_ms(500);
 		led_orange_toggle();
-		for (i = 0; i < 1000000; i++) {}
+		systick_delay_ms(500);
 		led_red_toggle();
-		for (i = 0; i < 1000000; i++) {}
+		systick_delay_ms(500);
 		led_blue_toggle();
 	}
 }

--- a/Src/systick.c
+++ b/Src/systick.c
@@ -1,0 +1,63 @@
+#include <stm32f4xx.h>
+#include "systick.h"
+
+/* Internal system clock */
+#define SYSTEM_CLOCK_SPEED      16000000
+#define TRIGGER_EVERY_SEC       SYSTEM_CLOCK_SPEED
+#define TRIGGER_EVERY_MS        SYSTEM_CLOCK_SPEED / 1000
+
+static uint32_t get_tick_counter(void);
+
+uint32_t global_tick_counter;
+
+/* Systick is a non GPIO Hardware level module so configure it using bare metal register writes.
+ */
+void systick_initialize(void)
+{
+    /* Disable the module while configuring it */
+    SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;
+
+    /* Set the clock source as the internal 16 MHz crystal */
+    SysTick->CTRL |= SysTick_CTRL_CLKSOURCE_Msk;
+
+    /* Load value to trigger the systick interrupt every millisecond, but subtract 1 because it includes decrementing to 0 */
+    SysTick->LOAD = TRIGGER_EVERY_MS - 1U;
+
+    /* Clear the current value to reset the timer by flagging the COUNTFLAG bit-16 in the SysTick->CTRL register*/
+    SysTick->VAL = 0;
+
+    /* Enable the systick interrupt */
+    SysTick->CTRL |= SysTick_CTRL_TICKINT_Msk;
+
+    /* Enable Systick module to start it up */
+    SysTick->CTRL |= SysTick_CTRL_ENABLE_Msk;
+}
+
+/* Accurate hardware delay function to replace software for-loop delay functions.
+ * Configured to take desired milliseconds as input.
+ */
+void systick_delay_ms(uint32_t delay)
+{
+    uint32_t current_tick_counter = get_tick_counter();
+    while ((get_tick_counter() - current_tick_counter) <= delay) {}
+}
+
+/* Function to get the global tick counter.
+ * Necessary because there could be race conditions when trying to access a global variable
+ * without it being inside of a critical section.
+ */
+static uint32_t get_tick_counter(void)
+{
+    uint32_t local_tick_counter;
+    __disable_irq();
+    local_tick_counter = global_tick_counter;
+    __enable_irq();
+
+    return local_tick_counter;
+}
+
+// cppcheck-suppress unusedFunction
+void SysTick_Handler(void)
+{
+    ++global_tick_counter;
+}


### PR DESCRIPTION
Using for-loops and software delays are not accurate compared to hardware timers. Add systick interrupt functionality to measure accurate delays for blinking LEDs and other future uses where delays might be necessary.

Systick is not a GPIO hardware block so it was not implemented using a custom HAL. In order to keep it decoupled from other hardware blocks, I implemented it using bare metal register reads and writes.