### PR TITLE
feat(assert handler): implement assert handling to sanity check code

### DIFF
--- a/Inc/assert_handler.h
+++ b/Inc/assert_handler.h
@@ -1,0 +1,31 @@
+#ifndef ASSERT_HANDLER_
+#define ASSERT_HANDLER_
+
+/* Purpose of a custom assert handler in embedded systems is to be used for error handling and debugging.
+ * The idea is to be able to easily see where the assert handler got called in the function call stack while debugging,
+ * and use LEDs to visually show the program is stuck in the assert handler. It's an easy and simple way to see
+ * an assertion failed and also makes it easy to track it down where something went wrong in the code.
+ * Assert handling can also capture information like the file name, line number, and expression that failed.
+ *
+ * The practical applications of using an assert_handler is for sanity checking configuration settings inside of init() functions.
+ *	- Checking configurations to match expectations
+ *	- Checking to make sure init() functions are called before using functions within that module such as setting output
+ *
+ * First wrap an assert macro in a define. This is standard industry practice to switch it on or off
+ * at compile time if you choose to do so.
+ *
+ * The do while loop is a common idiom used in C to create a macro that behaves like a single statement. It ensures the macro
+ * can be used safely with or without surrounding braces. It mainly prevents potential issues when the macro is used in if-else
+ * statements.
+ */
+#define ASSERT(expression)	\
+	do { \
+		if (!(expression)) { \
+			assert_handler(); \
+		} \
+	} while(0)
+
+void assert_handler(void);
+#endif /* ASSERT_HANDLER_ */
+
+

--- a/Inc/gpio.h
+++ b/Inc/gpio.h
@@ -3,6 +3,7 @@
 
 #include <stm32f4xx.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 typedef enum {
 	LED_GREEN,
@@ -18,12 +19,22 @@ typedef enum {
 	GPIO_MODE_ANALOG,
 }gpio_mode_e;
 
+/* Struct that holds all the attributes of a single pin. This struct is the basis for abstracting away
+ * direct register reads and writes in the custom GPIO HAL.
+ * Pin name is needed because it'll allow accessing the named pin from the gpio_board_pins[] array */
 typedef struct {
+	gpio_pin_names_e pin_name;
 	GPIO_TypeDef* port;
 	uint8_t pin_number;
 	uint8_t mode;
 }gpio_pin_t;
 
+void gpio_default_initialize(void);
+bool gpio_config_compare(gpio_pin_names_e pin_to_check,
+			 gpio_pin_names_e expected_pin_name,
+			 const GPIO_TypeDef* expected_port,
+			 uint8_t expected_pin_number,
+			 uint8_t expected_mode);
 void gpio_mode_set(gpio_pin_names_e pin, gpio_mode_e mode);
 void gpio_data_output_toggle(gpio_pin_names_e pin_name);
 void gpio_data_output_set(gpio_pin_names_e pin_name);

--- a/Inc/led.h
+++ b/Inc/led.h
@@ -1,12 +1,8 @@
 #ifndef LED_H_
 #define LED_H_
 
-void led_initialize(void);
-void led_green_off(void);
-void led_green_toggle(void);
-void led_orange_toggle(void);
-void led_red_toggle(void);
-void led_blue_off(void);
-void led_blue_toggle(void);
+#include "gpio.h"
 
+void led_initialize(void);
+void led_toggle(gpio_pin_names_e led_color);
 #endif /* LED_H_ */

--- a/Src/assert_handler.c
+++ b/Src/assert_handler.c
@@ -1,0 +1,30 @@
+#include "assert_handler.h"
+#include "led.h"
+#include "gpio.h"
+#include "systick.h"
+
+/* The assertion should print where the assertion got triggered by showing the file and line number.
+ * This functionality of tracing the code is just another tool to aid in debugging the software */
+void assert_handler(void)
+{
+    /* Toggle a software breakpoint to track in the debugger where it got triggered
+     * using the intrinsic __BKPT() function from CMSIS. This breakpoint raises a SIGTRAP to GDB and completely
+     * halts the program when its hit.
+     *
+     * The assert handler should still continue to the infinite loop of blinking the red and blue LEDs as a visual cue
+     * the program failed an assert check when the debugger is not on. This is useful if after flashing the code something
+     * goes on and the debugger has not been attached yet. If the debugger is on, then the breakpoint should hit and
+     * automatically pause the debugger at this point since it's already known the program will enter the assert handler.
+     */
+    if (CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk) {
+        __BKPT(0);
+    }
+
+    while (1) {
+        /* Should infinite loop while toggling LEDs to visually signal we're caught in the assert handler after flashing */
+        led_toggle(LED_RED);
+        systick_delay_ms(500);
+        led_toggle(LED_BLUE);
+        systick_delay_ms(500);
+    }
+}

--- a/Src/gpio.c
+++ b/Src/gpio.c
@@ -1,16 +1,18 @@
 #include <stm32f4xx.h>
+#include <stdbool.h>
 #include "gpio.h"
 
+#define GPIO_BOARD_PINS_LENGTH sizeof(gpio_board_pins)/sizeof(gpio_board_pins[0])
 
 /* Array to map high level pin names (an enum) such as LED_GREEN to the pin's attributes (a struct).
  * This centralizes all the info one would need about a pin, such as the port, pin number, etc.
  * This array is the core implementation of abstracting away the low level register interactions from the user.
  */
 static const gpio_pin_t gpio_board_pins[] = {
-    [LED_GREEN] =   {GPIOD, 12, GPIO_MODE_OUTPUT},
-    [LED_ORANGE] =  {GPIOD, 13, GPIO_MODE_OUTPUT},
-    [LED_RED] =     {GPIOD, 14, GPIO_MODE_OUTPUT},
-    [LED_BLUE] =    {GPIOD, 15, GPIO_MODE_OUTPUT},
+    [LED_GREEN] =   {LED_GREEN, GPIOD, 12, GPIO_MODE_OUTPUT},
+    //[LED_ORANGE] =  {LED_ORANGE, GPIOD, 13, GPIO_MODE_OUTPUT},
+    [LED_RED] =     {LED_RED, GPIOD, 14, GPIO_MODE_OUTPUT},
+    [LED_BLUE] =    {LED_BLUE, GPIOD, 15, GPIO_MODE_OUTPUT},
 };
 
 /* Mapping pin numbers to their corresponding MODE register as a 2D array.
@@ -49,6 +51,28 @@ static const uint32_t gpio_odr_register_bit[] = {
     [14] = GPIO_ODR_OD14,
     [15] = GPIO_ODR_OD15,
 };
+
+void gpio_default_initialize(void)
+{
+    volatile uint8_t i;
+    for (i = 0; i < GPIO_BOARD_PINS_LENGTH; i++) {
+        gpio_mode_set(gpio_board_pins[i].pin_name, gpio_board_pins[i].mode);
+    }
+}
+
+bool gpio_config_compare(gpio_pin_names_e pin_to_check,
+			 gpio_pin_names_e expected_pin_name,
+			 const GPIO_TypeDef* expected_port,
+			 uint8_t expected_pin_number,
+			 uint8_t expected_mode)
+{
+    const gpio_pin_t test_pin = gpio_board_pins[pin_to_check];
+
+    return (test_pin.pin_name == expected_pin_name) &&
+            (test_pin.port == expected_port) &&
+            (test_pin.pin_number == expected_pin_number) &&
+            (test_pin.mode == expected_mode);
+}
 
 void gpio_mode_set(gpio_pin_names_e pin_name, gpio_mode_e mode)
 {

--- a/Src/led.c
+++ b/Src/led.c
@@ -1,37 +1,30 @@
 #include <stm32f4xx.h>
 #include "led.h"
 #include "gpio.h"
-/* User Manual UM1472 states:
+#include "assert_handler.h"
 
-User Green LED:    I/O PD12
-User Orange LED: I/O PD13
-User Red LED:    I/O PD14
-User Blue LED:    I/O PD15*/
-
+/* Driver layer that interacts with the custom GPIO HAL underneath it.
+ * All the LED initialization should happen in this function.
+ */
 void led_initialize(void)
 {
     /* Need to enable the clock connected to GPIO Port D */
     RCC->AHB1ENR |= RCC_AHB1ENR_GPIODEN;
+    
+    gpio_mode_set(LED_GREEN, GPIO_MODE_OUTPUT);
+    gpio_mode_set(LED_RED, GPIO_MODE_OUTPUT);
+    gpio_mode_set(LED_BLUE, GPIO_MODE_OUTPUT);
+
+    /* Sanity check to make sure the pin configurations are set the way they should be */
+    ASSERT(gpio_config_compare(LED_GREEN, LED_GREEN, GPIOD, 12, GPIO_MODE_OUTPUT));
+    ASSERT(gpio_config_compare(LED_RED, LED_RED, GPIOD, 14, GPIO_MODE_OUTPUT));
+    ASSERT(gpio_config_compare(LED_BLUE, LED_BLUE, GPIOD, 15, GPIO_MODE_OUTPUT));
 }
 
-/* PD 12 */
-void led_green_toggle(void)
+/* Function to toggle the desired LED color using the color as the input parameter.
+ * The gpio_pin_names_e enum holds all the names of the pins being used for this project in "gpio.h"
+ */
+void led_toggle(gpio_pin_names_e led_color)
 {
-    gpio_data_output_toggle(LED_GREEN);
-}
-
-/* Orange LED PD 13 */
-void led_orange_toggle(void)
-{
-    gpio_data_output_toggle(LED_ORANGE);
-}
-
-void led_red_toggle(void)
-{
-    gpio_data_output_toggle(LED_RED);
-}
-
-void led_blue_toggle(void)
-{
-    gpio_data_output_toggle(LED_BLUE);
+    gpio_data_output_toggle(led_color);
 }

--- a/Src/main.c
+++ b/Src/main.c
@@ -2,25 +2,17 @@
 #include "led.h"
 #include "gpio.h"
 #include "systick.h"
+#include "assert_handler.h"
 
 int main(void)
 {
-	//volatile unsigned int i;
+	gpio_default_initialize();
 	led_initialize();
 	systick_initialize();
-	gpio_mode_set(LED_GREEN, GPIO_MODE_OUTPUT);
-	gpio_mode_set(LED_ORANGE, GPIO_MODE_OUTPUT);
-	gpio_mode_set(LED_RED, GPIO_MODE_OUTPUT);
-	gpio_mode_set(LED_BLUE, GPIO_MODE_OUTPUT);
 
 	while (1) {
-		systick_delay_ms(500);
-		led_green_toggle();
-		systick_delay_ms(500);
-		led_orange_toggle();
-		systick_delay_ms(500);
-		led_red_toggle();
-		systick_delay_ms(500);
-		led_blue_toggle();
+		systick_delay_ms(1000);
+		led_toggle(LED_GREEN);
+		ASSERT(0);
 	}
 }


### PR DESCRIPTION
Add assert functionality to make sure the program is behaving in the expected manner at different points throughout the code. A good use case is sanity checking pin configurations before using them, and to make sure the initialization codes for driver files have been called. It makes the assumptions of the programmer explicit and obvious by removing all doubts of their intentions.

Add a new function in gpio.* to check expected configurations versus the actual set configurations of pins.

The code in main.c has been refactored to only blink the green LED to show all the asserts are passing.

Modify led.* to implement the new assert handling logic inside of the led_initialize() function.