### PR TITLE
refactor(adc_dma): redo logic for getting values from the ADC

### DIFF
--- a/Inc/adc.h
+++ b/Inc/adc.h
@@ -2,7 +2,10 @@
 #define ADC_H_
 #include <stdint.h>
 
+#define ADC_CHANNELS_USED       4
+
 void adc_initialize(void);
-void adc_dma_get_values(void);
+void adc_dma_get_values(uint16_t adc_dma_values[]);
+void adc_dma_print_values(const uint16_t adc_dma_values[]);
 
 #endif /* ADC_H_ */

--- a/Src/main.c
+++ b/Src/main.c
@@ -12,8 +12,12 @@ int main(void)
 	uart2_initialize();
 	ir_receiver_initialize();
 	adc_initialize();
+
+	uint16_t adc_values[ADC_CHANNELS_USED];
+
 	while (1) {
-		adc_dma_get_values();
+		adc_dma_get_values(adc_values);
+		adc_dma_print_values(adc_values);
 		led_toggle(LED_GREEN);
 		systick_delay_ms(1000);
 	}


### PR DESCRIPTION
The adc_dma_get_values() function should be used to extract the values from the edge detecting sensor. This should be done by abstracting away all the logic inside of the ADC driver. By having the get_values() function take an input array and copy the values into it inside of a critical section, the edge detecting module can be free to use those values without having to worry about interrupt handling of the DMA interrupt.

This decouples the code as much as possible and all the sensor needs to do is get the adc values, and use those values inside of its own module.

TODO: code the logic for the QRE1113 sensor by abstracting away the channels and representing the values it gets from the ADC as locations/placements of the sensors such as front left, back right, etc.