### PR TITLE
comments(trace): add clarifying comments to the TRACE macro

### DIFF
--- a/Inc/trace.h
+++ b/Inc/trace.h
@@ -1,7 +1,22 @@
 #ifndef TRACE_H_
 #define TRACE_H_
 
-#define TRACE(fmt, ...) trace("%s:%d: " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__)
+/* Macro to serve as a shorthand with same syntax as using standard printf() that also prints
+ * the file and line numbers.
+ *
+ * Example:
+ * TRACE("Error code: %d", error_code) would expand to -> trace("file.c:42: Error code: %d\n", "file.c", 42, error_code)
+ *
+ * "fmt" represents the format string for the log message.
+ * "..." represents variadic arguments to hold the placeholders in the above format string.
+ *
+ * Inside the trace() function:
+ * "%s:%d: " fmt "\n" is a combined format string using the file name/line as a prefix to the user provided fmt string.
+ * __FILE__ and __LINE__ are predefined macros.
+ * ##__VA_ARGS__ "variadic arguments" expands to the additional arguments provided to the TRACE macro call with "..."
+ *	It represents any additional arguments after "fmt" because "fmt" represents the first argument of TRACE 
+ */
+#define TRACE(fmt, ...) trace("%s:%d: " fmt, __FILE__, __LINE__, ##__VA_ARGS__)
 
 /* Additional define to easily disable and enable traces in the build.
  * Traces may affect the timing of the code so useful to turn them all off at once. 

--- a/Src/adc.c
+++ b/Src/adc.c
@@ -119,7 +119,7 @@ void adc_dma_get_values(uint16_t adc_dma_values[])
 void adc_dma_print_values(const uint16_t adc_dma_values[])
 {
     for (uint8_t i = 0; i < ADC_CHANNELS_USED; i++) {
-        TRACE("Channel %u: %u", (i + 10), adc_dma_values[i]);
+        TRACE("Channel %u: %u\n", (i + 10), adc_dma_values[i]);
     }
 }
 

--- a/Src/trace.c
+++ b/Src/trace.c
@@ -14,6 +14,22 @@ void trace_initialize(void)
  */
 void trace(const char *format, ...)
 {
+    /* va_list is a type defined in <stdarg.h> and is used to retrieve the addtional arguments passed to the variadic function.
+     *      This holds the arguments from "..." passed into the trace() function.
+     *
+     * va_start is a macro that initializes "va_list args" from the previous line so it can be used to access the variadic arguments.
+     *      The order of parameters (args, format) is important because va_start needs to know the LAST FIXED PARAMETER before
+     *      the variadic arguments. So if trace was defined like so trace(const char *format, const int number, ...)
+     *      then va_start would need to be initialized as va_start(args, number).
+     *
+     * vprintf() is a variation of printf() that takes in the list of arguments (va_list) instead of each variable argument directly.
+     *      It uses the "va_list args" to replace the format specifiers in "format" with the corresponding values in "args". 
+     *
+     * va_end() is a macro that cleans up the "args" variable after the variadic arguments have been processed.
+     *      This is important to do after you're done with the variadic arguments to avoid potential stack corruption or
+     *      accessing invalid memory later down the line. This is to ensure the stack is correctly restored to its state before
+     *      va_start was called.
+     */
     va_list args;
     va_start(args, format);
     vprintf(format, args);


### PR DESCRIPTION
Detail the syntax for the TRACE macro and how it exactly works with the trace() function because it looks a bit confusing at first. Add comments in both the trace.h and trace.c files.

Edit TRACE macro to not implicitly add the "\n" at the end to make it match the behavior of traditional printf().