### PR TITLE
refactor(tb6612fng): rename variables to be more sensible

### DIFF
--- a/Inc/tb6612fng.h
+++ b/Inc/tb6612fng.h
@@ -3,12 +3,12 @@
 
 #include <stdint.h>
 
-/* Motor directions*/
+/* Motor direction mode. Clockwise/counterclockwise. */
 typedef enum {
-    TB6612FNG_DIRECTION_STOP,
-    TB6612FNG_DIRECTION_FORWARD,
-    TB6612FNG_DIRECTION_REVERSE
-}tb6612fng_direction_e;
+    TB6612FNG_MODE_STOP,
+    TB6612FNG_MODE_FORWARD,
+    TB6612FNG_MODE_REVERSE
+}tb6612fng_mode_e;
 
 /* The orientation of the motors will be opposite of each other 
  * which means I need to be able to control them independently between them
@@ -21,7 +21,7 @@ typedef enum {
 
 void tb6612fng_initialize(void);
 void tb6612fng_test(void);
-void tb6612fng_direction(tb6612fng_motor_e motor, tb6612fng_direction_e direction);
-void tb6612fng_speed(tb6612fng_motor_e motor, uint8_t duty_cycle);
+void tb6612fng_mode_set(tb6612fng_motor_e motor, tb6612fng_mode_e mode);
+void tb6612fng_dutycycle_set(tb6612fng_motor_e motor, uint8_t duty_cycle);
 
 #endif /* TB6612FNG_H_ */

--- a/Src/tb6612fng.c
+++ b/Src/tb6612fng.c
@@ -49,54 +49,54 @@ void tb6612fng_initialize(void)
 void tb6612fng_test(void)
 {
     const uint8_t speeds[] = {100, 75, 50, 25};
-    const tb6612fng_direction_e directions[] = {
-        TB6612FNG_DIRECTION_FORWARD,
-        TB6612FNG_DIRECTION_REVERSE,
-        TB6612FNG_DIRECTION_FORWARD,
-        TB6612FNG_DIRECTION_REVERSE,
+    const tb6612fng_mode_e modes[] = {
+        TB6612FNG_MODE_FORWARD,
+        TB6612FNG_MODE_REVERSE,
+        TB6612FNG_MODE_FORWARD,
+        TB6612FNG_MODE_REVERSE,
     };
     const uint8_t length = sizeof(speeds)/sizeof(speeds[0]);
 
     for (uint8_t i = 0; i < length; i++) {
-        if (i == TB6612FNG_DIRECTION_FORWARD) {
+        if (i == TB6612FNG_MODE_FORWARD) {
             TRACE("TB6612FNG direction: Forward and Speed: %d\n", speeds[i]);
         } else {
             TRACE("TB6612FNG direction: Reverse and Speed: %d\n", speeds[i]);
         }
-        tb6612fng_direction(TB6612FNG_MOTOR_LEFT, directions[i]);
-        tb6612fng_speed(TB6612FNG_MOTOR_LEFT, speeds[i]);
-        tb6612fng_direction(TB6612FNG_MOTOR_RIGHT, directions[i]);
-        tb6612fng_speed(TB6612FNG_MOTOR_RIGHT, speeds[i]);
+        tb6612fng_mode_set(TB6612FNG_MOTOR_LEFT, modes[i]);
+        tb6612fng_dutycycle_set(TB6612FNG_MOTOR_LEFT, speeds[i]);
+        tb6612fng_mode_set(TB6612FNG_MOTOR_RIGHT, modes[i]);
+        tb6612fng_dutycycle_set(TB6612FNG_MOTOR_RIGHT, speeds[i]);
         systick_delay_ms(2000);
         
-        tb6612fng_direction(TB6612FNG_MOTOR_LEFT, TB6612FNG_DIRECTION_STOP);
-        tb6612fng_speed(TB6612FNG_MOTOR_LEFT, 0);
-        tb6612fng_direction(TB6612FNG_MOTOR_RIGHT, TB6612FNG_DIRECTION_STOP);
-        tb6612fng_speed(TB6612FNG_MOTOR_RIGHT, 0);
+        tb6612fng_mode_set(TB6612FNG_MOTOR_LEFT, TB6612FNG_MODE_STOP);
+        tb6612fng_dutycycle_set(TB6612FNG_MOTOR_LEFT, 0);
+        tb6612fng_mode_set(TB6612FNG_MOTOR_RIGHT, TB6612FNG_MODE_STOP);
+        tb6612fng_dutycycle_set(TB6612FNG_MOTOR_RIGHT, 0);
         systick_delay_ms(1500);
     }
 }
 
-void tb6612fng_direction(tb6612fng_motor_e motor, tb6612fng_direction_e direction)
+void tb6612fng_mode_set(tb6612fng_motor_e motor, tb6612fng_mode_e mode)
 {
     /* Datasheet for the breakboard gives the truth table for the following directions */
-    switch (direction) {
-        case TB6612FNG_DIRECTION_FORWARD:
+    switch (mode) {
+        case TB6612FNG_MODE_FORWARD:
             gpio_data_output_set(input_pins[motor].in1);
             gpio_data_output_clear(input_pins[motor].in2);
             break;
-        case TB6612FNG_DIRECTION_REVERSE:
+        case TB6612FNG_MODE_REVERSE:
             gpio_data_output_set(input_pins[motor].in2);
             gpio_data_output_clear(input_pins[motor].in1);
             break;
-        case TB6612FNG_DIRECTION_STOP:
+        case TB6612FNG_MODE_STOP:
             gpio_data_output_clear(input_pins[motor].in1);
             gpio_data_output_clear(input_pins[motor].in2);
             break;
     }
 }
 
-void tb6612fng_speed(tb6612fng_motor_e motor, uint8_t duty_cycle)
+void tb6612fng_dutycycle_set(tb6612fng_motor_e motor, uint8_t duty_cycle)
 {
     pwm_e pwm_channel;
 


### PR DESCRIPTION
The tb6612fng motor driver file shouldn't really understand the idea of "speeds" and "directions" for the motors. The motor driver in and of itself really only knows to set the duty cycle for the PWM and setting the logic for the motor control pins to move them in a specific direction clockwise or counterclockwise. I edited the variable and function names to better reflect this.

The concept of "speed" and "direction" should be expressed in the application level layer code, not in the firmware for the motor driver.